### PR TITLE
탈퇴 회원 복구 흐름 개선

### DIFF
--- a/src/main/java/com/j9/bestmoments/controller/AuthController.java
+++ b/src/main/java/com/j9/bestmoments/controller/AuthController.java
@@ -1,7 +1,6 @@
 package com.j9.bestmoments.controller;
 
-import com.j9.bestmoments.domain.Token;
-import com.j9.bestmoments.dto.response.JwtTokenDto;
+import com.j9.bestmoments.dto.response.LoginDto;
 import com.j9.bestmoments.dto.response.OAuthUserInfoDto;
 import com.j9.bestmoments.service.GoogleAuthService;
 import com.j9.bestmoments.service.OAuthService;
@@ -35,7 +34,7 @@ public class AuthController {
 
     @GetMapping("/login/{oAuthProvider}")
     @Operation(summary = "OAuth 인증코드로 로그인/회원가입", description = "oAuthProvider: google")
-    public ResponseEntity<JwtTokenDto> login(@PathVariable String oAuthProvider, @RequestParam String code) {
+    public ResponseEntity<LoginDto> login(@PathVariable String oAuthProvider, @RequestParam String code) {
         OAuthService oAuthService = switch (oAuthProvider) {
             case "google" -> googleAuthService;
             default -> throw new OAuth2AuthenticationException("존재하지 않는 OAuth 인증 방식입니다.");
@@ -43,7 +42,7 @@ public class AuthController {
         OAuthUserInfoDto oAuthUserInfo = oAuthService.getUserInfo(code);
         Member member = memberService.findOrSaveByOAuthInfo(oAuthUserInfo);
 
-        JwtTokenDto jwtToken = tokenService.create(member);
+        LoginDto jwtToken = tokenService.create(member);
         return ResponseEntity.ok(jwtToken);
     }
 

--- a/src/main/java/com/j9/bestmoments/dto/response/JwtTokenDto.java
+++ b/src/main/java/com/j9/bestmoments/dto/response/JwtTokenDto.java
@@ -1,9 +1,0 @@
-package com.j9.bestmoments.dto.response;
-
-public record JwtTokenDto(
-        String grantType,
-        String accessToken,
-        String refreshToken
-) {
-
-}

--- a/src/main/java/com/j9/bestmoments/dto/response/LoginDto.java
+++ b/src/main/java/com/j9/bestmoments/dto/response/LoginDto.java
@@ -1,0 +1,12 @@
+package com.j9.bestmoments.dto.response;
+
+import java.time.LocalDateTime;
+
+public record LoginDto(
+        String grantType,
+        String accessToken,
+        String refreshToken,
+        LocalDateTime deletedAt
+) {
+
+}

--- a/src/main/java/com/j9/bestmoments/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/j9/bestmoments/jwt/JwtTokenProvider.java
@@ -1,6 +1,5 @@
 package com.j9.bestmoments.jwt;
 
-import com.j9.bestmoments.dto.response.JwtTokenDto;
 import com.j9.bestmoments.domain.Member;
 import com.sun.security.auth.UserPrincipal;
 import io.jsonwebtoken.Claims;

--- a/src/main/java/com/j9/bestmoments/service/TokenService.java
+++ b/src/main/java/com/j9/bestmoments/service/TokenService.java
@@ -2,7 +2,7 @@ package com.j9.bestmoments.service;
 
 import com.j9.bestmoments.domain.Member;
 import com.j9.bestmoments.domain.Token;
-import com.j9.bestmoments.dto.response.JwtTokenDto;
+import com.j9.bestmoments.dto.response.LoginDto;
 import com.j9.bestmoments.jwt.JwtTokenProvider;
 import com.j9.bestmoments.repository.TokenRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class TokenService {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
-    public JwtTokenDto create(Member member) {
+    public LoginDto create(Member member) {
         String accessToken = jwtTokenProvider.generateAccessToken(member);
         String refreshToken = jwtTokenProvider.generateRefreshToken(member);
         Token token = Token.builder()
@@ -32,7 +32,7 @@ public class TokenService {
         log.error(token.getAccessToken());
         log.error(token.getRefreshToken());
         log.error(tokenRepository.findAll().get(0).getAccessToken());
-        return new JwtTokenDto("Bearer", accessToken, refreshToken);
+        return new LoginDto("Bearer", accessToken, refreshToken, member.getDeletedAt());
     }
 
     public Token findByAnyToken(String token) {


### PR DESCRIPTION
## 🚀 작업 내용

#### #8
- [x] 탈퇴 회원 복구 흐름 개선

## 📝 참고 사항

- 로그인 시 응답에 해당 사용자의 탈퇴 일자를 포함

#### 회원 탈퇴 복구 방식
- 클라이언트가 OAuth를 통한 로그인 요청
- 서버는 토큰과 탈퇴일자를 반환
- 탈퇴한 상태라면 클라이언트는 복구 여부를 사용자에게 요청
- 복구한다고 할 시 서버 측에 복구 요청
- 클라이언트는 이전에 함께 발급된 토큰을 사용

## 🖼️ 스크린샷

![image](https://github.com/Team-J9/BestMoments-Backend/assets/50670730/d72819f0-31af-4c2e-a69a-1d829660c00a)