### PR TITLE
My Video 컨트롤러 분리

### DIFF
--- a/src/main/java/com/j9/bestmoments/controller/MyVideoController.java
+++ b/src/main/java/com/j9/bestmoments/controller/MyVideoController.java
@@ -1,0 +1,92 @@
+package com.j9.bestmoments.controller;
+
+import com.j9.bestmoments.domain.Member;
+import com.j9.bestmoments.domain.Video;
+import com.j9.bestmoments.dto.request.VideoCreateDto;
+import com.j9.bestmoments.dto.request.VideoUpdateDto;
+import com.j9.bestmoments.dto.response.VideoFindDto;
+import com.j9.bestmoments.dto.response.VideoPreviewDto;
+import com.j9.bestmoments.service.MemberService;
+import com.j9.bestmoments.service.VideoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/my-videos")
+@Tag(name = "My Video", description = "내 동영상 관련 API")
+public class MyVideoController {
+
+    private final VideoService videoService;
+    private final MemberService memberService;
+
+    @Operation(summary = "동영상 업로드")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<VideoFindDto> upload(@ModelAttribute @Valid VideoCreateDto createDto) {
+        String id = SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString();
+        Member member = memberService.findById(id);
+        Video video = videoService.upload(member, createDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(VideoFindDto.of(video));
+    }
+
+    @Operation(summary = "동영상 정보 수정")
+    @PatchMapping("/{videoId}")
+    public ResponseEntity<VideoFindDto> update(@PathVariable UUID videoId, @RequestBody VideoUpdateDto updateDto) {
+        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+        Member member = memberService.findById(memberId);
+        Video video = videoService.findById(videoId);
+        videoService.checkCanRead(member, video);
+        videoService.update(video, updateDto);
+        return ResponseEntity.ok(VideoFindDto.of(video));
+    }
+
+    @Operation(summary = "동영상 삭제 (휴지통으로 이동)")
+    @DeleteMapping("/{videoId}")
+    public ResponseEntity<VideoFindDto> softDelete(@PathVariable UUID videoId) {
+        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+        Member member = memberService.findById(memberId);
+        Video video = videoService.findById(videoId);
+        videoService.checkCanWrite(member, video);
+        videoService.softDelete(video);
+        return ResponseEntity.ok(VideoFindDto.of(video));
+    }
+
+    @Operation(summary = "동영상 복구 (휴지통에서 복구)")
+    @PostMapping("/{videoId}")
+    public ResponseEntity<VideoFindDto> restore(@PathVariable UUID videoId) {
+        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+        Member member = memberService.findById(memberId);
+        Video video = videoService.findById(videoId);
+        videoService.checkCanWrite(member, video);
+        videoService.restore(video);
+        return ResponseEntity.ok(VideoFindDto.of(video));
+    }
+
+    @Operation(summary = "내 휴지통 조회")
+    @GetMapping("/deleted")
+    public ResponseEntity<Page<VideoPreviewDto>> findDeletedVideos(Pageable pageable) {
+        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+        Page<Video> videos = videoService.findAllDeletedByUploaderId(memberId, pageable);
+        return ResponseEntity.ok(videos.map(VideoPreviewDto::of));
+    }
+
+}

--- a/src/main/java/com/j9/bestmoments/controller/VideoController.java
+++ b/src/main/java/com/j9/bestmoments/controller/VideoController.java
@@ -40,28 +40,6 @@ public class VideoController {
     private final VideoService videoService;
     private final MemberService memberService;
 
-    @Operation(summary = "동영상 업로드")
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<VideoFindDto> upload(@ModelAttribute @Valid VideoCreateDto createDto) {
-        String id = SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString();
-        Member member = memberService.findById(id);
-        Video video = videoService.upload(member, createDto);
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(VideoFindDto.of(video));
-    }
-
-    @Operation(summary = "동영상 정보 수정")
-    @PatchMapping("/{videoId}")
-    public ResponseEntity<VideoFindDto> update(@PathVariable UUID videoId, @RequestBody VideoUpdateDto updateDto) {
-        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-        Member member = memberService.findById(memberId);
-        Video video = videoService.findById(videoId);
-        videoService.checkCanRead(member, video);
-        videoService.update(video, updateDto);
-        return ResponseEntity.ok(VideoFindDto.of(video));
-    }
-
     @Operation(summary = "동영상 열람")
     @GetMapping("/{videoId}")
     public ResponseEntity<VideoFindDto> view(@PathVariable UUID videoId) {
@@ -70,36 +48,6 @@ public class VideoController {
         Video video = videoService.findById(videoId);
         videoService.checkCanRead(member, video);
         return ResponseEntity.ok(VideoFindDto.of(video));
-    }
-
-    @Operation(summary = "동영상 삭제 (휴지통으로 이동)")
-    @DeleteMapping("/{videoId}")
-    public ResponseEntity<VideoFindDto> softDelete(@PathVariable UUID videoId) {
-        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-        Member member = memberService.findById(memberId);
-        Video video = videoService.findById(videoId);
-        videoService.checkCanWrite(member, video);
-        videoService.softDelete(video);
-        return ResponseEntity.ok(VideoFindDto.of(video));
-    }
-
-    @Operation(summary = "동영상 복구 (휴지통에서 복구)")
-    @PostMapping("/{videoId}")
-    public ResponseEntity<VideoFindDto> restore(@PathVariable UUID videoId) {
-        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-        Member member = memberService.findById(memberId);
-        Video video = videoService.findById(videoId);
-        videoService.checkCanWrite(member, video);
-        videoService.restore(video);
-        return ResponseEntity.ok(VideoFindDto.of(video));
-    }
-
-    @Operation(summary = "내 휴지통 조회")
-    @GetMapping("/deleted")
-    public ResponseEntity<Page<VideoPreviewDto>> findDeletedVideos(Pageable pageable) {
-        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-        Page<Video> videos = videoService.findAllDeletedByUploaderId(memberId, pageable);
-        return ResponseEntity.ok(videos.map(VideoPreviewDto::of));
     }
 
     @Operation(summary = "사용자의 동영상 목록 조회")

--- a/src/main/java/com/j9/bestmoments/controller/VideoController.java
+++ b/src/main/java/com/j9/bestmoments/controller/VideoController.java
@@ -1,33 +1,18 @@
 package com.j9.bestmoments.controller;
 
-import com.j9.bestmoments.domain.Member;
 import com.j9.bestmoments.domain.Video;
-import com.j9.bestmoments.domain.VideoStatus;
-import com.j9.bestmoments.dto.request.VideoCreateDto;
-import com.j9.bestmoments.dto.request.VideoUpdateDto;
 import com.j9.bestmoments.dto.response.VideoFindDto;
 import com.j9.bestmoments.dto.response.VideoPreviewDto;
-import com.j9.bestmoments.service.MemberService;
 import com.j9.bestmoments.service.VideoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,23 +23,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class VideoController {
 
     private final VideoService videoService;
-    private final MemberService memberService;
 
     @Operation(summary = "동영상 열람")
     @GetMapping("/{videoId}")
     public ResponseEntity<VideoFindDto> view(@PathVariable UUID videoId) {
-        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-        Member member = memberService.findById(memberId);
-        Video video = videoService.findById(videoId);
-        videoService.checkCanRead(member, video);
+        Video video = videoService.findPublicById(videoId);
         return ResponseEntity.ok(VideoFindDto.of(video));
     }
 
     @Operation(summary = "사용자의 동영상 목록 조회")
     @GetMapping("/by/{memberId}")
     public ResponseEntity<Page<VideoPreviewDto>> findAllByUploaderId(@PathVariable UUID memberId, Pageable pageable) {
-        UUID currentMemberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-        Page<Video> videos = videoService.findAllByUploaderId(currentMemberId, memberId, pageable);
+        Page<Video> videos = videoService.findAllPublicByUploaderId(memberId, pageable);
         return ResponseEntity.ok(videos.map(VideoPreviewDto::of));
     }
 

--- a/src/main/java/com/j9/bestmoments/domain/Video.java
+++ b/src/main/java/com/j9/bestmoments/domain/Video.java
@@ -76,12 +76,4 @@ public class Video {
         this.videoStatus = videoStatus;
     }
 
-    public boolean canBeWrittenBy(Member member) {
-        return member.equals(uploader);
-    }
-
-    public boolean canBeReadBy(Member member) {
-        return videoStatus.equals(VideoStatus.PUBLIC) || canBeWrittenBy(member);
-    }
-
 }

--- a/src/main/java/com/j9/bestmoments/repository/VideoRepository.java
+++ b/src/main/java/com/j9/bestmoments/repository/VideoRepository.java
@@ -2,6 +2,7 @@ package com.j9.bestmoments.repository;
 
 import com.j9.bestmoments.domain.Video;
 import com.j9.bestmoments.domain.VideoStatus;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -11,8 +12,16 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface VideoRepository extends JpaRepository<Video, UUID> {
 
-    Page<Video> findAllByUploaderIdAndVideoStatusAndDeletedAtIsNull(UUID uploaderId, VideoStatus videoStatus, PageRequest pageRequest);
+    Page<Video> findAllByUploaderIdAndDeletedAtIsNotNull(UUID uploaderId, PageRequest pageRequest);
 
     Page<Video> findAllByUploaderIdAndDeletedAtIsNull(UUID uploaderId, PageRequest pageRequest);
+
+    Page<Video> findAllByUploaderIdAndVideoStatusAndDeletedAtIsNull(UUID uploaderId, VideoStatus videoStatus, PageRequest pageRequest);
+
+    Optional<Video> findByIdAndUploaderIdAndDeletedAtIsNotNull(UUID id, UUID uploaderId);
+
+    Optional<Video> findByIdAndVideoStatus(UUID id, VideoStatus videoStatus);
+
+    Optional<Video> findByIdAndUploaderId(UUID id, UUID uploaderId);
 
 }

--- a/src/main/java/com/j9/bestmoments/service/MemberService.java
+++ b/src/main/java/com/j9/bestmoments/service/MemberService.java
@@ -20,11 +20,6 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    public Member findById(String id) {
-        return memberRepository.findById(UUID.fromString(id))
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 유저입니다."));
-    }
-
     public Page<Member> findAll(Pageable pageable) {
         return memberRepository.findAll(PageRequest.of(
                 pageable.getPageNumber(), pageable.getPageSize()

--- a/src/main/java/com/j9/bestmoments/service/VideoService.java
+++ b/src/main/java/com/j9/bestmoments/service/VideoService.java
@@ -53,6 +53,21 @@ public class VideoService {
                 .orElseThrow(EntityNotFoundException::new);
     }
 
+    public Video findByIdAndUploaderId(UUID id, UUID memberId) {
+        return videoRepository.findByIdAndUploaderId(id, memberId)
+                .orElseThrow(EntityNotFoundException::new);
+    }
+
+    public Video findDeletedByIdAndUploaderId(UUID id, UUID memberId) {
+        return videoRepository.findByIdAndUploaderIdAndDeletedAtIsNotNull(id, memberId)
+                .orElseThrow(EntityNotFoundException::new);
+    }
+
+    public Video findPublicById(UUID id) {
+        return videoRepository.findByIdAndVideoStatus(id, VideoStatus.PUBLIC)
+                .orElseThrow(EntityNotFoundException::new);
+    }
+
     @Transactional
     public Video update(Video video, VideoUpdateDto updateDto) {
         video.setTitle(updateDto.title());
@@ -76,40 +91,26 @@ public class VideoService {
         return video;
     }
 
-    // 조회할 수 있는 영상만 조회
-    public Page<Video> findAllByUploaderId(UUID currentMemberId, UUID memberId, Pageable pageable) {
-        if (currentMemberId.equals(memberId)) {
-            return videoRepository.findAllByUploaderIdAndDeletedAtIsNull(
-                    memberId,
-                    PageRequest.of(pageable.getPageNumber(), pageable.getPageSize())
-            );
-        }
-        return videoRepository.findAllByUploaderIdAndVideoStatusAndDeletedAtIsNull(
-                memberId,
-                VideoStatus.PUBLIC,
-                PageRequest.of(pageable.getPageNumber(), pageable.getPageSize())
-        );
-    }
-
-    public Page<Video> findAllDeletedByUploaderId(UUID memberId, Pageable pageable) {
+    public Page<Video> findAllActivatedByUploaderId(UUID memberId, Pageable pageable) {
         return videoRepository.findAllByUploaderIdAndDeletedAtIsNull(
                 memberId,
                 PageRequest.of(pageable.getPageNumber(), pageable.getPageSize())
         );
     }
 
-    public void checkCanRead(Member member, Video video) {
-        if (video.canBeReadBy(member)) {
-            return;
-        }
-        throw new AccessDeniedException("권한 없음");
+    public Page<Video> findAllDeletedByUploaderId(UUID memberId, Pageable pageable) {
+        return videoRepository.findAllByUploaderIdAndDeletedAtIsNotNull(
+                memberId,
+                PageRequest.of(pageable.getPageNumber(), pageable.getPageSize())
+        );
     }
 
-    public void checkCanWrite(Member member, Video video) {
-        if (video.canBeWrittenBy(member)) {
-            return;
-        }
-        throw new AccessDeniedException("권한 없음");
+    public Page<Video> findAllPublicByUploaderId(UUID memberId, Pageable pageable) {
+        return videoRepository.findAllByUploaderIdAndVideoStatusAndDeletedAtIsNull(
+                memberId,
+                VideoStatus.PUBLIC,
+                PageRequest.of(pageable.getPageNumber(), pageable.getPageSize())
+        );
     }
 
 }


### PR DESCRIPTION
## 🚀 작업 내용

#### #14
- [x] 기존 동영상 컨트롤러에서 해당하는 API 분리
  - 업로드
  - 열람
  - 정보 수정
  - 휴지통으로 보내기
  - 휴지통에서 복구
  - 휴지통 조회

## 📝 참고 사항

- 기존 Video 컨트롤러에서의 현재 사용자 id를 구분하는 메서드를 분리
  - 기존 Video에서는 Public 상태의 동영상만을 조회
  - My Video에서는 현재 사용자의 동영상만을 조회
- 기존 Video 컨트롤러는 로그인하지 않아도 접근 가능케 함

## 🖼️ 스크린샷

### before
> ![image](https://github.com/Team-J9/BestMoments-Backend/assets/50670730/b194b3cf-c705-4093-9654-3dbd4925dbac)

### after
> ![image](https://github.com/Team-J9/BestMoments-Backend/assets/50670730/79ecb1ff-e4bb-426a-8c69-c285d75f53e0)
> ![image](https://github.com/Team-J9/BestMoments-Backend/assets/50670730/79acccff-59f9-41be-ae2a-f73d8454cb8c)


