### PR TITLE
사용자 및 동영상 관련 테스트 코드 작성

### DIFF
--- a/src/main/java/com/j9/bestmoments/domain/Member.java
+++ b/src/main/java/com/j9/bestmoments/domain/Member.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -27,8 +28,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
 @Getter
-@EqualsAndHashCode
 @NoArgsConstructor
+@EqualsAndHashCode(of = {"id", "oauthProvider", "oauthId"})
 @EntityListeners(AuditingEntityListener.class)
 public class Member implements UserDetails {
 

--- a/src/main/java/com/j9/bestmoments/domain/Video.java
+++ b/src/main/java/com/j9/bestmoments/domain/Video.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Cascade;
@@ -24,6 +25,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Getter
 @NoArgsConstructor
+@EqualsAndHashCode(of = {"id"})
 @EntityListeners(AuditingEntityListener.class)
 public class Video {
 

--- a/src/main/java/com/j9/bestmoments/repository/VideoRepository.java
+++ b/src/main/java/com/j9/bestmoments/repository/VideoRepository.java
@@ -20,7 +20,7 @@ public interface VideoRepository extends JpaRepository<Video, UUID> {
 
     Optional<Video> findByIdAndUploaderIdAndDeletedAtIsNotNull(UUID id, UUID uploaderId);
 
-    Optional<Video> findByIdAndVideoStatus(UUID id, VideoStatus videoStatus);
+    Optional<Video> findByIdAndVideoStatusAndDeletedAtIsNull(UUID id, VideoStatus videoStatus);
 
     Optional<Video> findByIdAndUploaderId(UUID id, UUID uploaderId);
 

--- a/src/main/java/com/j9/bestmoments/service/VideoService.java
+++ b/src/main/java/com/j9/bestmoments/service/VideoService.java
@@ -64,7 +64,7 @@ public class VideoService {
     }
 
     public Video findPublicById(UUID id) {
-        return videoRepository.findByIdAndVideoStatus(id, VideoStatus.PUBLIC)
+        return videoRepository.findByIdAndVideoStatusAndDeletedAtIsNull(id, VideoStatus.PUBLIC)
                 .orElseThrow(EntityNotFoundException::new);
     }
 

--- a/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.j9.bestmoments.service;
 
 import com.j9.bestmoments.domain.Member;
+import com.j9.bestmoments.dto.response.OAuthUserInfoDto;
 import com.j9.bestmoments.repository.MemberRepository;
 import com.j9.bestmoments.util.MemberGenerator;
 import jakarta.persistence.EntityNotFoundException;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
 @SpringBootTest
@@ -68,6 +70,38 @@ public class MemberServiceTest {
         memberRepository.save(member1);
         UUID id = member1.getId();
         Assertions.assertThrows(EntityNotFoundException.class, () -> memberService.findByIdAndDeletedAtIsNull(id));
+    }
+
+    @Test
+    void findOrSaveByOAuthInfo_Find() {
+        OAuthUserInfoDto dto = new OAuthUserInfoDto(
+                member1.getOauthProvider(),
+                member1.getOauthId(),
+                null,
+                null,
+                null
+        );
+        Member foundMember = memberService.findOrSaveByOAuthInfo(dto);
+        Assertions.assertEquals(member1, foundMember);
+    }
+
+    @Test
+    void findOrSaveByOAuthInfo_Save() {
+        OAuthUserInfoDto dto = new OAuthUserInfoDto(
+                member1.getOauthProvider(),
+                UUID.randomUUID().toString(),
+                null,
+                null,
+                null
+        );
+        Page<Member> previousMembers = memberService.findAll(PageRequest.of(0, 100));
+
+        memberService.findOrSaveByOAuthInfo(dto);
+        Page<Member> currentMembers = memberService.findAll(PageRequest.of(0, 100));
+
+        long previousMembersCount = previousMembers.stream().count();
+        long currentMembersCount = currentMembers.stream().count();
+        Assertions.assertEquals(previousMembersCount + 1, currentMembersCount);
     }
 
 

--- a/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
@@ -125,7 +125,12 @@ public class MemberServiceTest {
         Assertions.assertThrows(EntityNotFoundException.class, () -> memberService.findByIdAndDeletedAtIsNull(id));
     }
 
-
-
+    @Test
+    void restore() {
+        memberService.softDelete(member1);
+        memberService.restore(member1);
+        UUID id = member1.getId();
+        Assertions.assertDoesNotThrow(() -> memberService.findByIdAndDeletedAtIsNull(id));
+    }
 
 }

--- a/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.j9.bestmoments.service;
 
 import com.j9.bestmoments.domain.Member;
+import com.j9.bestmoments.dto.request.MemberUpdateDto;
 import com.j9.bestmoments.dto.response.OAuthUserInfoDto;
 import com.j9.bestmoments.repository.MemberRepository;
 import com.j9.bestmoments.util.MemberGenerator;
@@ -102,6 +103,19 @@ public class MemberServiceTest {
         long previousMembersCount = previousMembers.stream().count();
         long currentMembersCount = currentMembers.stream().count();
         Assertions.assertEquals(previousMembersCount + 1, currentMembersCount);
+    }
+
+    @Test
+    void update() {
+        String changedName = "changedName";
+        String changedDescription = "changedDescription";
+        MemberUpdateDto dto = new MemberUpdateDto(changedName, changedDescription);
+
+        memberService.update(member1, dto);
+
+        Member foundMember = memberService.findById(member1.getId());
+        Assertions.assertEquals(changedName, foundMember.getName());
+        Assertions.assertEquals(changedDescription, foundMember.getDescription());
     }
 
 

--- a/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
@@ -55,5 +55,20 @@ public class MemberServiceTest {
         Assertions.assertThrows(EntityNotFoundException.class, () -> memberService.findById(id));
     }
 
+    @Test
+    void findByIdAndDeletedAtIsNull_Success() {
+        UUID id = member1.getId();
+        Member foundMember = memberService.findByIdAndDeletedAtIsNull(id);
+        Assertions.assertEquals(member1, foundMember);
+    }
+
+    @Test
+    void findByIdAndDeletedAtIsNull_Fail() {
+        member1.softDelete();
+        memberRepository.save(member1);
+        UUID id = member1.getId();
+        Assertions.assertThrows(EntityNotFoundException.class, () -> memberService.findByIdAndDeletedAtIsNull(id));
+    }
+
 
 }

--- a/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
@@ -3,8 +3,11 @@ package com.j9.bestmoments.service;
 import com.j9.bestmoments.domain.Member;
 import com.j9.bestmoments.repository.MemberRepository;
 import com.j9.bestmoments.util.MemberGenerator;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,23 +21,38 @@ public class MemberServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    @Test
-    void findAll() {
-        Member member1 = MemberGenerator.createGoogleUser("user1");
-        Member member2 = MemberGenerator.createGoogleUser("user2");
-        Member member3 = MemberGenerator.createGoogleUser("user3");
+    private final Member member1 = MemberGenerator.createGoogleUser("user1");
+    private final Member member2 = MemberGenerator.createGoogleUser("user2");
+    private final Member member3 = MemberGenerator.createGoogleUser("user3");
 
+    @BeforeEach
+    void createMembers() {
         memberRepository.save(member1);
         memberRepository.save(member2);
         memberRepository.save(member3);
+    }
 
+    @Test
+    void findAll() {
         List<Member> foundMembers = memberService
                 .findAll(PageRequest.of(0, 100))
                 .toList();
-
         Assertions.assertTrue(foundMembers.contains(member1));
         Assertions.assertTrue(foundMembers.contains(member2));
         Assertions.assertTrue(foundMembers.contains(member3));
+    }
+
+    @Test
+    void findById_Success() {
+        UUID id = member1.getId();
+        Member foundMember = memberService.findById(id);
+        Assertions.assertEquals(member1, foundMember);
+    }
+
+    @Test
+    void findById_Fail() {
+        UUID id = UUID.randomUUID();
+        Assertions.assertThrows(EntityNotFoundException.class, () -> memberService.findById(id));
     }
 
 

--- a/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.j9.bestmoments.service;
 
 import com.j9.bestmoments.domain.Member;
+import com.j9.bestmoments.domain.MemberRole;
 import com.j9.bestmoments.dto.request.MemberUpdateDto;
 import com.j9.bestmoments.dto.response.OAuthUserInfoDto;
 import com.j9.bestmoments.repository.MemberRepository;
@@ -24,9 +25,9 @@ public class MemberServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    private final Member member1 = MemberGenerator.createGoogleUser("user1");
-    private final Member member2 = MemberGenerator.createGoogleUser("user2");
-    private final Member member3 = MemberGenerator.createGoogleUser("user3");
+    private final Member member1 = MemberGenerator.createGoogleMember("user1", MemberRole.USER);
+    private final Member member2 = MemberGenerator.createGoogleMember("user2", MemberRole.USER);
+    private final Member member3 = MemberGenerator.createGoogleMember("user3", MemberRole.USER);
 
     @BeforeEach
     void createMembers() {

--- a/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
@@ -1,0 +1,41 @@
+package com.j9.bestmoments.service;
+
+import com.j9.bestmoments.domain.Member;
+import com.j9.bestmoments.repository.MemberRepository;
+import com.j9.bestmoments.util.MemberGenerator;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+
+@SpringBootTest
+public class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void findAll() {
+        Member member1 = MemberGenerator.createGoogleUser("user1");
+        Member member2 = MemberGenerator.createGoogleUser("user2");
+        Member member3 = MemberGenerator.createGoogleUser("user3");
+
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        memberRepository.save(member3);
+
+        List<Member> foundMembers = memberService
+                .findAll(PageRequest.of(0, 100))
+                .toList();
+
+        Assertions.assertTrue(foundMembers.contains(member1));
+        Assertions.assertTrue(foundMembers.contains(member2));
+        Assertions.assertTrue(foundMembers.contains(member3));
+    }
+
+
+}

--- a/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/MemberServiceTest.java
@@ -118,5 +118,14 @@ public class MemberServiceTest {
         Assertions.assertEquals(changedDescription, foundMember.getDescription());
     }
 
+    @Test
+    void softDelete() {
+        memberService.softDelete(member1);
+        UUID id = member1.getId();
+        Assertions.assertThrows(EntityNotFoundException.class, () -> memberService.findByIdAndDeletedAtIsNull(id));
+    }
+
+
+
 
 }

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -91,4 +91,23 @@ public class VideoServiceTest {
         Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findByIdAndUploaderId(randomId, memberId));
     }
 
+    @Test
+    @Transactional
+    void findDeletedByIdAndUploaderId_Success() {
+        UUID videoId = publicVideo.getId();
+        UUID memberId = member.getId();
+        publicVideo.softDelete();
+        videoRepository.save(publicVideo);
+        Video foundVideo = videoService.findDeletedByIdAndUploaderId(videoId, memberId);
+        Assertions.assertEquals(publicVideo, foundVideo);
+    }
+
+    @Test
+    @Transactional
+    void findDeletedByIdAndUploaderId_Fail() {
+        UUID videoId = publicVideo.getId();
+        UUID memberId = member.getId();
+        Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findDeletedByIdAndUploaderId(videoId, memberId));
+    }
+
 }

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -142,4 +142,14 @@ public class VideoServiceTest {
         Assertions.assertEquals(changedVideoStatus, foundVideo.getVideoStatus());
     }
 
+    @Test
+    @Transactional
+    void softDelete() {
+        videoService.softDelete(publicVideo);
+        UUID id = publicVideo.getId();
+        UUID uploaderId = publicVideo.getUploader().getId();
+        Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findPublicById(id));
+        Assertions.assertDoesNotThrow(() -> videoService.findDeletedByIdAndUploaderId(id, uploaderId));
+    }
+
 }

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -9,7 +9,9 @@ import com.j9.bestmoments.repository.MemberRepository;
 import com.j9.bestmoments.repository.VideoRepository;
 import com.j9.bestmoments.util.MemberGenerator;
 import com.j9.bestmoments.util.VideoGenerator;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +55,21 @@ public class VideoServiceTest {
         Assertions.assertTrue(foundVideos.contains(publicVideo));
         Assertions.assertTrue(foundVideos.contains(privateVideo));
         Assertions.assertTrue(foundVideos.contains(urlPublicVideo));
+    }
+
+    @Test
+    @Transactional
+    void findById_Success() {
+        UUID id = publicVideo.getId();
+        Video foundVideo = videoService.findById(id);
+        Assertions.assertEquals(publicVideo, foundVideo);
+    }
+
+    @Test
+    @Transactional
+    void findById_Fail() {
+        UUID id = UUID.randomUUID();
+        Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findById(id));
     }
 
 }

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -72,4 +72,23 @@ public class VideoServiceTest {
         Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findById(id));
     }
 
+    @Test
+    @Transactional
+    void findByIdAndUploaderId_Success() {
+        UUID videoId = publicVideo.getId();
+        UUID memberId = member.getId();
+        Video foundVideo = videoService.findByIdAndUploaderId(videoId, memberId);
+        Assertions.assertEquals(publicVideo, foundVideo);
+    }
+
+    @Test
+    @Transactional
+    void findByIdAndUploaderId_Fail() {
+        UUID videoId = publicVideo.getId();
+        UUID memberId = member.getId();
+        UUID randomId = UUID.randomUUID();
+        Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findByIdAndUploaderId(videoId, randomId));
+        Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findByIdAndUploaderId(randomId, memberId));
+    }
+
 }

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -163,4 +163,18 @@ public class VideoServiceTest {
         Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findDeletedByIdAndUploaderId(id, uploaderId));
     }
 
+    @Test
+    @Transactional
+    void findAllActivatedByUploaderId() {
+        videoService.softDelete(urlPublicVideo);
+
+        List<Video> foundVideos = videoService
+                .findAllActivatedByUploaderId(member.getId(), PageRequest.of(0, 100))
+                .toList();
+
+        Assertions.assertTrue(foundVideos.contains(publicVideo));
+        Assertions.assertTrue(foundVideos.contains(privateVideo));
+        Assertions.assertFalse(foundVideos.contains(urlPublicVideo));
+    }
+
 }

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -191,4 +191,16 @@ public class VideoServiceTest {
         Assertions.assertTrue(foundVideos.contains(urlPublicVideo));
     }
 
+    @Test
+    @Transactional
+    void findAllPublicByUploaderId() {
+        List<Video> foundVideos = videoService
+                .findAllPublicByUploaderId(member.getId(), PageRequest.of(0, 100))
+                .toList();
+
+        Assertions.assertTrue(foundVideos.contains(publicVideo));
+        Assertions.assertFalse(foundVideos.contains(privateVideo));
+        Assertions.assertFalse(foundVideos.contains(urlPublicVideo));
+    }
+
 }

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -152,4 +152,15 @@ public class VideoServiceTest {
         Assertions.assertDoesNotThrow(() -> videoService.findDeletedByIdAndUploaderId(id, uploaderId));
     }
 
+    @Test
+    @Transactional
+    void restore() {
+        videoService.softDelete(publicVideo);
+        videoService.restore(publicVideo);
+        UUID id = publicVideo.getId();
+        UUID uploaderId = publicVideo.getUploader().getId();
+        Assertions.assertDoesNotThrow(() -> videoService.findPublicById(id));
+        Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findDeletedByIdAndUploaderId(id, uploaderId));
+    }
+
 }

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -5,6 +5,7 @@ import com.j9.bestmoments.domain.MemberRole;
 import com.j9.bestmoments.domain.Video;
 import com.j9.bestmoments.domain.VideoStatus;
 import com.j9.bestmoments.dto.request.VideoCreateDto;
+import com.j9.bestmoments.dto.request.VideoUpdateDto;
 import com.j9.bestmoments.repository.MemberRepository;
 import com.j9.bestmoments.repository.VideoRepository;
 import com.j9.bestmoments.util.MemberGenerator;
@@ -123,6 +124,22 @@ public class VideoServiceTest {
     void findPublicById_Fail() {
         Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findPublicById(privateVideo.getId()));
         Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findPublicById(urlPublicVideo.getId()));
+    }
+
+    @Test
+    @Transactional
+    void update() {
+        String changedTitle = "changedTitle";
+        String changedDescription = "changedDescription";
+        VideoStatus changedVideoStatus = VideoStatus.PRIVATE;
+        VideoUpdateDto dto = new VideoUpdateDto(changedTitle, changedDescription, changedVideoStatus);
+
+        videoService.update(publicVideo, dto);
+
+        Video foundVideo = videoService.findById(publicVideo.getId());
+        Assertions.assertEquals(changedTitle, foundVideo.getTitle());
+        Assertions.assertEquals(changedDescription, foundVideo.getDescription());
+        Assertions.assertEquals(changedVideoStatus, foundVideo.getVideoStatus());
     }
 
 }

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -1,0 +1,58 @@
+package com.j9.bestmoments.service;
+
+import com.j9.bestmoments.domain.Member;
+import com.j9.bestmoments.domain.MemberRole;
+import com.j9.bestmoments.domain.Video;
+import com.j9.bestmoments.domain.VideoStatus;
+import com.j9.bestmoments.dto.request.VideoCreateDto;
+import com.j9.bestmoments.repository.MemberRepository;
+import com.j9.bestmoments.repository.VideoRepository;
+import com.j9.bestmoments.util.MemberGenerator;
+import com.j9.bestmoments.util.VideoGenerator;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+public class VideoServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private VideoService videoService;
+    @Autowired
+    private VideoRepository videoRepository;
+
+    private Member member = MemberGenerator.createGoogleMember("user1", MemberRole.USER);
+    private Video publicVideo = VideoGenerator.createVideo(member, "video1", VideoStatus.PUBLIC);
+    private Video privateVideo = VideoGenerator.createVideo(member, "video2", VideoStatus.PRIVATE);
+    private Video urlPublicVideo = VideoGenerator.createVideo(member, "video3", VideoStatus.URL_PUBLIC);
+
+    @BeforeEach
+    @Transactional
+    void setup() {
+        memberRepository.save(member);
+        videoRepository.save(publicVideo);
+        videoRepository.save(privateVideo);
+        videoRepository.save(urlPublicVideo);
+    }
+
+    @Test
+    @Transactional
+    void findAll() {
+        List<Video> foundVideos = videoService
+                .findAll(PageRequest.of(0, 100))
+                .toList();
+        Assertions.assertTrue(foundVideos.contains(publicVideo));
+        Assertions.assertTrue(foundVideos.contains(privateVideo));
+        Assertions.assertTrue(foundVideos.contains(urlPublicVideo));
+    }
+
+}

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -110,4 +110,19 @@ public class VideoServiceTest {
         Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findDeletedByIdAndUploaderId(videoId, memberId));
     }
 
+    @Test
+    @Transactional
+    void findPublicById_Success() {
+        UUID videoId = publicVideo.getId();
+        Video foundVideo = videoService.findPublicById(videoId);
+        Assertions.assertEquals(publicVideo, foundVideo);
+    }
+
+    @Test
+    @Transactional
+    void findPublicById_Fail() {
+        Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findPublicById(privateVideo.getId()));
+        Assertions.assertThrows(EntityNotFoundException.class, () -> videoService.findPublicById(urlPublicVideo.getId()));
+    }
+
 }

--- a/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
+++ b/src/test/java/com/j9/bestmoments/service/VideoServiceTest.java
@@ -177,4 +177,18 @@ public class VideoServiceTest {
         Assertions.assertFalse(foundVideos.contains(urlPublicVideo));
     }
 
+    @Test
+    @Transactional
+    void findAllDeletedByUploaderId() {
+        videoService.softDelete(urlPublicVideo);
+
+        List<Video> foundVideos = videoService
+                .findAllDeletedByUploaderId(member.getId(), PageRequest.of(0, 100))
+                .toList();
+
+        Assertions.assertFalse(foundVideos.contains(publicVideo));
+        Assertions.assertFalse(foundVideos.contains(privateVideo));
+        Assertions.assertTrue(foundVideos.contains(urlPublicVideo));
+    }
+
 }

--- a/src/test/java/com/j9/bestmoments/util/MemberGenerator.java
+++ b/src/test/java/com/j9/bestmoments/util/MemberGenerator.java
@@ -5,25 +5,14 @@ import com.j9.bestmoments.domain.MemberRole;
 
 public final class MemberGenerator {
 
-    public static Member createGoogleUser(String name) {
+    public static Member createGoogleMember(String name, MemberRole memberRole) {
         return Member.builder()
                 .oauthId(name + "'s google_oauth_id")
                 .oauthProvider("google")
                 .name(name)
                 .email(name + "@gmail.com")
                 .profileImageUrl(name + "'s profileImgUrl")
-                .role(MemberRole.USER)
-                .build();
-    }
-
-    public static Member createGoogleAdmin(String name) {
-        return Member.builder()
-                .oauthId(name + "'s google_oauth_id")
-                .oauthProvider("google")
-                .name(name)
-                .email(name + "@gmail.com")
-                .profileImageUrl(name + "'s profileImgUrl")
-                .role(MemberRole.ADMIN)
+                .role(memberRole)
                 .build();
     }
 

--- a/src/test/java/com/j9/bestmoments/util/MemberGenerator.java
+++ b/src/test/java/com/j9/bestmoments/util/MemberGenerator.java
@@ -1,0 +1,30 @@
+package com.j9.bestmoments.util;
+
+import com.j9.bestmoments.domain.Member;
+import com.j9.bestmoments.domain.MemberRole;
+
+public final class MemberGenerator {
+
+    public static Member createGoogleUser(String name) {
+        return Member.builder()
+                .oauthId(name + "'s google_oauth_id")
+                .oauthProvider("google")
+                .name(name)
+                .email(name + "@gmail.com")
+                .profileImageUrl(name + "'s profileImgUrl")
+                .role(MemberRole.USER)
+                .build();
+    }
+
+    public static Member createGoogleAdmin(String name) {
+        return Member.builder()
+                .oauthId(name + "'s google_oauth_id")
+                .oauthProvider("google")
+                .name(name)
+                .email(name + "@gmail.com")
+                .profileImageUrl(name + "'s profileImgUrl")
+                .role(MemberRole.ADMIN)
+                .build();
+    }
+
+}

--- a/src/test/java/com/j9/bestmoments/util/VideoGenerator.java
+++ b/src/test/java/com/j9/bestmoments/util/VideoGenerator.java
@@ -1,0 +1,19 @@
+package com.j9.bestmoments.util;
+
+import com.j9.bestmoments.domain.Member;
+import com.j9.bestmoments.domain.Video;
+import com.j9.bestmoments.domain.VideoStatus;
+
+public final class VideoGenerator {
+
+    public static Video createVideo(Member member, String title, VideoStatus videoStatus) {
+        return Video.builder()
+                .uploader(member)
+                .fileUrl(title + "'s fileUrl")
+                .title(title)
+                .description(title + "'s description")
+                .videoStatus(videoStatus)
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 🚀 작업 내용

#### \#
- MemberService 메서드 테스트
- VideoService 메서드 테스트
- **공개된 동영상 조회 시 삭제된 동영상 또한 조회되는 현상 수정**
- Member, Video 엔티티에 `@EqualsAndHashCode` 명시 및 필드 설정

## 📝 참고 사항

- 테스트 메서드의 이름을 테스트한 메서드의 이름과 같게 작성
- 이상의 이유로, 편리한 비교를 위해 `@Display 어노테이션`을 사용하지 않음

## 🖼️ 스크린샷

![image](https://github.com/user-attachments/assets/3ba865e9-bdbe-4e18-9294-37503e1bcfe6)

![image](https://github.com/user-attachments/assets/76c6b2c9-0d0d-4d25-b836-4b4896373825)

![image](https://github.com/user-attachments/assets/f602f655-7f84-4dfb-8358-beaa824cf41d)
