### PR TITLE
Auth api 수정

### DIFF
--- a/src/main/java/com/j9/bestmoments/config/SecurityConfig.java
+++ b/src/main/java/com/j9/bestmoments/config/SecurityConfig.java
@@ -36,9 +36,9 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth -> auth
                                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                                .requestMatchers("/auth/login/**").permitAll()
+                                .requestMatchers("/auth/**").permitAll()
                                 .requestMatchers("/admin/**").hasRole(MemberRole.ADMIN.getValue())
-        //                        .anyRequest().permitAll()
+//                                .anyRequest().permitAll()
                                 .anyRequest().authenticated()
                 )
 

--- a/src/main/java/com/j9/bestmoments/controller/AuthController.java
+++ b/src/main/java/com/j9/bestmoments/controller/AuthController.java
@@ -32,10 +32,10 @@ public class AuthController {
     private final MemberService memberService;
     private final TokenService tokenService;
 
-    @GetMapping("/login/{oAuthProvider}")
-    @Operation(summary = "OAuth 인증코드로 로그인/회원가입", description = "oAuthProvider: google")
-    public ResponseEntity<LoginDto> login(@PathVariable String oAuthProvider, @RequestParam String code) {
-        OAuthService oAuthService = switch (oAuthProvider) {
+    @GetMapping("/{registrationId}/callback")
+    @Operation(summary = "OAuth 인증코드로 로그인/회원가입", description = "registrationId: google")
+    public ResponseEntity<LoginDto> login(@PathVariable String registrationId, @RequestParam String code) {
+        OAuthService oAuthService = switch (registrationId) {
             case "google" -> googleAuthService;
             default -> throw new OAuth2AuthenticationException("존재하지 않는 OAuth 인증 방식입니다.");
         };

--- a/src/main/java/com/j9/bestmoments/controller/AuthController.java
+++ b/src/main/java/com/j9/bestmoments/controller/AuthController.java
@@ -16,6 +16,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -48,14 +49,14 @@ public class AuthController {
 
     @PatchMapping("/logout")
     @Operation(summary = "로그아웃", description = "토큰을 강제로 만료시킵니다.")
-    public ResponseEntity<String> logout(@RequestHeader("Authorization") String token) {
+    public ResponseEntity<String> logout(@RequestBody String token) {
         tokenService.expire(token);
         return ResponseEntity.ok().body("로그아웃에 성공하였습니다.");
     }
 
     @PatchMapping("/refresh")
     @Operation(summary = "액세스토큰 재발급", description = "리프래시 토큰을 통해 재발급받습니다.")
-    public ResponseEntity<String> refreshToken(@RequestHeader("Authorization") String refreshToken) {
+    public ResponseEntity<String> refreshToken(@RequestBody String refreshToken) {
         String accessToken = tokenService.refresh(refreshToken);
         return ResponseEntity.ok().body(accessToken);
     }


### PR DESCRIPTION
## 🚀 작업 내용

#### \#
- [x] oAuth 로그인 api url 수정
- [x] 토큰 만료 및 리프래쉬 시 토큰을 header가 아닌 body로 받게 함

## 📝 참고 사항

- oAuth 로그인 api url : `/auth/login/{oAuthProviderId}` -> `/auth/{registrationId}/callback`
- oAuth 콜백을 백엔드에서 바로 받아 불필요한 flow를 제거

## 🖼️ 스크린샷

