### PR TITLE
파일 저장 방식 수정

### DIFF
--- a/src/main/java/com/j9/bestmoments/domain/Video.java
+++ b/src/main/java/com/j9/bestmoments/domain/Video.java
@@ -1,13 +1,10 @@
 package com.j9.bestmoments.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
@@ -34,9 +31,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class Video {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @GenericGenerator(name="uuid2", strategy = "uuid2")
-    @Column(columnDefinition = "BINARY(16)")
     private UUID id;
     private String fileUrl;
     private String title;
@@ -58,9 +52,9 @@ public class Video {
     private List<String> tags = new ArrayList<>();
 
     @Builder
-    public Video(Member uploader, String fileUrl, String title, String description, VideoStatus videoStatus) {
+    public Video(Member uploader, String title, String description, VideoStatus videoStatus) {
+        this.id = UUID.randomUUID();
         this.uploader = uploader;
-        this.fileUrl = fileUrl;
         this.title = title;
         this.description = description;
         this.videoStatus = videoStatus;
@@ -88,6 +82,10 @@ public class Video {
 
     public void setVideoTags(List<String> tags) {
         this.tags = tags;
+    }
+
+    public void setFileUrl(String fileUrl) {
+        this.fileUrl = fileUrl;
     }
 
 }

--- a/src/main/java/com/j9/bestmoments/service/GoogleCloudStorageService.java
+++ b/src/main/java/com/j9/bestmoments/service/GoogleCloudStorageService.java
@@ -1,6 +1,8 @@
 package com.j9.bestmoments.service;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.j9.bestmoments.domain.Member;
+import com.j9.bestmoments.util.FileNameGenerator;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.UUID;
@@ -35,17 +37,19 @@ public class GoogleCloudStorageService implements StorageService {
 
     // 다운로드 링크를 반환
     @Override
-    public String uploadFile(MultipartFile file) {
-        String fileName = String.format("%s.%s", UUID.randomUUID(), file.getContentType().split("/")[1]);
+    public String uploadFile(MultipartFile file, String fileName) {
+        String contentType = file.getContentType().split("/")[1];
         BlobId blobId = BlobId.of(bucketName, fileName);
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
         try {
             storage.create(blobInfo, file.getInputStream());
         }
         catch (Exception e) {
+
             throw new RuntimeException("IOException");
         }
         log.info("blobId = {}", blobId);
-        return String.format("https://storage.cloud.google.com/%s/%s", bucketName, fileName);
+        return String.format("https://storage.cloud.google.com/%s/%s.%s", bucketName, fileName, contentType);
     }
+
 }

--- a/src/main/java/com/j9/bestmoments/service/MemberService.java
+++ b/src/main/java/com/j9/bestmoments/service/MemberService.java
@@ -5,6 +5,7 @@ import com.j9.bestmoments.dto.response.OAuthUserInfoDto;
 import com.j9.bestmoments.domain.MemberRole;
 import com.j9.bestmoments.domain.Member;
 import com.j9.bestmoments.repository.MemberRepository;
+import com.j9.bestmoments.util.FileNameGenerator;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -65,7 +66,8 @@ public class MemberService {
             member.setDescription(memberUpdateDto.description());
         }
         if (memberUpdateDto.file() != null) {
-            String profileImageUrl = googleCloudStorageService.uploadFile(memberUpdateDto.file());
+            String fileName = FileNameGenerator.generateProfileImageFileName(member);
+            String profileImageUrl = googleCloudStorageService.uploadFile(memberUpdateDto.file(), fileName);
             member.setProfileImageUrl(profileImageUrl);
         }
         return memberRepository.save(member);

--- a/src/main/java/com/j9/bestmoments/service/StorageService.java
+++ b/src/main/java/com/j9/bestmoments/service/StorageService.java
@@ -4,6 +4,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface StorageService {
 
-    String uploadFile(MultipartFile file);
+    String uploadFile(MultipartFile file, String fileName);
 
 }

--- a/src/main/java/com/j9/bestmoments/service/VideoService.java
+++ b/src/main/java/com/j9/bestmoments/service/VideoService.java
@@ -28,7 +28,7 @@ public class VideoService {
 
     @Transactional
     public Video upload(Member member, VideoCreateDto createDto) {
-        String fileUrl = storageService.uploadFile(createDto.file());
+        String fileUrl = storageService.uploadFile(createDto.file(), createDto.title());
         Video video = Video.builder()
                 .fileUrl(fileUrl)
                 .uploader(member)

--- a/src/main/java/com/j9/bestmoments/service/VideoService.java
+++ b/src/main/java/com/j9/bestmoments/service/VideoService.java
@@ -7,6 +7,7 @@ import com.j9.bestmoments.domain.VideoStatus;
 import com.j9.bestmoments.dto.request.VideoCreateDto;
 import com.j9.bestmoments.dto.request.VideoUpdateDto;
 import com.j9.bestmoments.repository.VideoRepository;
+import com.j9.bestmoments.util.FileNameGenerator;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.security.auth.message.AuthException;
 import java.util.List;
@@ -28,14 +29,15 @@ public class VideoService {
 
     @Transactional
     public Video upload(Member member, VideoCreateDto createDto) {
-        String fileUrl = storageService.uploadFile(createDto.file(), createDto.title());
         Video video = Video.builder()
-                .fileUrl(fileUrl)
                 .uploader(member)
                 .videoStatus(createDto.videoStatus())
                 .title(createDto.title())
                 .description(createDto.description())
                 .build();
+        String fileName = FileNameGenerator.generateVideoFileName(video);
+        String fileUrl = storageService.uploadFile(createDto.file(), fileName);
+        video.setFileUrl(fileUrl);
         videoRepository.save(video);
         return video;
     }

--- a/src/main/java/com/j9/bestmoments/util/FileNameGenerator.java
+++ b/src/main/java/com/j9/bestmoments/util/FileNameGenerator.java
@@ -1,0 +1,21 @@
+package com.j9.bestmoments.util;
+
+import com.j9.bestmoments.domain.Member;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public final class FileNameGenerator {
+
+    public static String generateProfileImageFileName(Member member) {
+        String memberId = member.getId().toString();
+        String dateString = generateDateString();
+        return String.format("profile/%s/%s", memberId, dateString);
+    }
+
+    private static String generateDateString() {
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+        return now.format(formatter);
+    }
+
+}

--- a/src/main/java/com/j9/bestmoments/util/FileNameGenerator.java
+++ b/src/main/java/com/j9/bestmoments/util/FileNameGenerator.java
@@ -1,6 +1,7 @@
 package com.j9.bestmoments.util;
 
 import com.j9.bestmoments.domain.Member;
+import com.j9.bestmoments.domain.Video;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -10,6 +11,11 @@ public final class FileNameGenerator {
         String memberId = member.getId().toString();
         String dateString = generateDateString();
         return String.format("profile/%s/%s", memberId, dateString);
+    }
+
+    public static String generateVideoFileName(Video video) {
+        String videoId = video.getId().toString();
+        return String.format("video/%s/video-origin", videoId);
     }
 
     private static String generateDateString() {


### PR DESCRIPTION
## 🚀 작업 내용

파일 관리를 위한 파일 저장 방식 수정

#### #33
- [x] 동영상/프로필 종류 별 패키지 분리
- [x] 규칙적인 파일명 지정

## 📝 참고 사항

- 동영상 저장 시 `/video/{videoId}/video-origin`으로 저장
- 프로필 이미지 저장 시 `/profile/{memberId}/{yyyyMMddHHmmss}`으로 저장

## 🖼️ 스크린샷

![image](https://github.com/user-attachments/assets/1ce31d8e-9140-473f-81a3-b14de883857a)

![image](https://github.com/user-attachments/assets/bef5bbee-5fff-4bb9-93f3-200d397523d7)


close #33 