### PR TITLE
인코딩된 영상 링크들을 제공하도록 수정

### DIFF
--- a/src/main/java/com/j9/bestmoments/converter/StringListConverter.java
+++ b/src/main/java/com/j9/bestmoments/converter/StringListConverter.java
@@ -1,0 +1,23 @@
+package com.j9.bestmoments.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final String SEPARATOR = ",";
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        return String.join(SEPARATOR, attribute);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        return Arrays.asList(dbData.split(SEPARATOR));
+    }
+
+}

--- a/src/main/java/com/j9/bestmoments/domain/Video.java
+++ b/src/main/java/com/j9/bestmoments/domain/Video.java
@@ -1,5 +1,7 @@
 package com.j9.bestmoments.domain;
 
+import com.j9.bestmoments.converter.StringListConverter;
+import jakarta.persistence.Convert;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -35,6 +37,7 @@ public class Video {
     private String videoUrl;
     private String thumbnailUrl;
     @Lob
+    @Convert(converter = StringListConverter.class)
     private List<String> encodedVideoUrls;
 
     private String title;

--- a/src/main/java/com/j9/bestmoments/domain/Video.java
+++ b/src/main/java/com/j9/bestmoments/domain/Video.java
@@ -19,7 +19,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
-import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -32,8 +31,12 @@ public class Video {
 
     @Id
     private UUID id;
+
     private String videoUrl;
     private String thumbnailUrl;
+    @Lob
+    private List<String> encodedVideoUrls;
+
     private String title;
     @Lob
     private String description;
@@ -60,6 +63,7 @@ public class Video {
         this.description = description;
         this.videoStatus = videoStatus;
         this.isDeleted = false;
+        this.encodedVideoUrls = new ArrayList<>();
     }
 
     public void softDelete() {
@@ -88,6 +92,10 @@ public class Video {
 
     public void setVideoUrl(String videoUrl) {
         this.videoUrl = videoUrl;
+    }
+
+    public void addEncodedVideoUrl(String videoUrl) {
+        this.encodedVideoUrls.add(videoUrl);
     }
 
     public void setThumbnailUrl(String thumbnailUrl) {

--- a/src/main/java/com/j9/bestmoments/dto/response/VideoFindDto.java
+++ b/src/main/java/com/j9/bestmoments/dto/response/VideoFindDto.java
@@ -3,11 +3,12 @@ package com.j9.bestmoments.dto.response;
 import com.j9.bestmoments.domain.Video;
 import com.j9.bestmoments.domain.VideoStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record VideoFindDto(
         UUID id,
-        String videoUrl,
+        List<String> videoUrls,
         String thumbnailUrl,
         String title,
         String description,
@@ -20,7 +21,7 @@ public record VideoFindDto(
     public static VideoFindDto of (Video video) {
         return new VideoFindDto(
                 video.getId(),
-                video.getVideoUrl(),
+                video.getEncodedVideoUrls(),
                 video.getThumbnailUrl(),
                 video.getTitle(),
                 video.getDescription(),

--- a/src/main/java/com/j9/bestmoments/service/FfmpegService.java
+++ b/src/main/java/com/j9/bestmoments/service/FfmpegService.java
@@ -1,5 +1,6 @@
 package com.j9.bestmoments.service;
 
+import jakarta.persistence.criteria.CriteriaBuilder.In;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,17 @@ public class FfmpegService {
     @Async
     public void encodeVideo(String inputFilePath, String outputFilePath, String resolution) {
         try {
+            // 해상도가 홀수인 경우 조정
+            int width = Integer.parseInt(resolution.split("x")[0]);
+            int height = Integer.parseInt(resolution.split("x")[0]);
+            if (width % 2 == 1) {
+                width++;
+            }
+            if (height % 2 == 1) {
+                height++;
+            }
+            resolution = width + "x" + height;
+
             ProcessBuilder processBuilder = new ProcessBuilder(
                     ffmpegPath, "-i", inputFilePath, "-s", resolution, "-codec:v", "libx264", outputFilePath
             );

--- a/src/main/java/com/j9/bestmoments/service/FileNameProvider.java
+++ b/src/main/java/com/j9/bestmoments/service/FileNameProvider.java
@@ -1,4 +1,4 @@
-package com.j9.bestmoments.util;
+package com.j9.bestmoments.service;
 
 import com.j9.bestmoments.domain.Member;
 import com.j9.bestmoments.domain.Video;
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import org.springframework.web.multipart.MultipartFile;
 
-public final class FileNameGenerator {
+public final class FileNameProvider {
 
     public static String generateProfileImageFileName(Member member, MultipartFile file) {
         String memberId = member.getId().toString();

--- a/src/main/java/com/j9/bestmoments/service/MemberService.java
+++ b/src/main/java/com/j9/bestmoments/service/MemberService.java
@@ -6,9 +6,7 @@ import com.j9.bestmoments.domain.MemberRole;
 import com.j9.bestmoments.domain.Member;
 import com.j9.bestmoments.repository.MemberRepository;
 import com.j9.bestmoments.service.storageService.StorageService;
-import com.j9.bestmoments.util.FileNameGenerator;
 import jakarta.persistence.EntityNotFoundException;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -68,7 +66,7 @@ public class MemberService {
             member.setDescription(memberUpdateDto.description());
         }
         if (memberUpdateDto.file() != null) {
-            String fileName = FileNameGenerator.generateProfileImageFileName(member, memberUpdateDto.file());
+            String fileName = FileNameProvider.generateProfileImageFileName(member, memberUpdateDto.file());
             String profileImageUrl = googleCloudStorageService.uploadFile(memberUpdateDto.file(), fileName);
             member.setProfileImageUrl(profileImageUrl);
         }

--- a/src/main/java/com/j9/bestmoments/service/VideoService.java
+++ b/src/main/java/com/j9/bestmoments/service/VideoService.java
@@ -61,7 +61,7 @@ public class VideoService {
             if (height >= originalHeight) {
                 break;
             }
-            int width = originalWidth * originalHeight / height;
+            int width = originalWidth * height / originalHeight;
             String resolution = width + "x" + height;
             String encodedVideoUrl = uploadEncodedVideo(originVideoUrl, resolution);
             video.addEncodedVideoUrl(encodedVideoUrl);

--- a/src/main/java/com/j9/bestmoments/service/VideoService.java
+++ b/src/main/java/com/j9/bestmoments/service/VideoService.java
@@ -49,6 +49,7 @@ public class VideoService {
         // 원본 사이즈 인코딩
         String resolution = ffmpegService.getVideoResolution(originVideoUrl);
         String encodedVideoUrl = uploadEncodedVideo(originVideoUrl, resolution);
+        video.addEncodedVideoUrl(encodedVideoUrl);
 
         // 1/2 사이즈 인코딩
         String halfResolution = Arrays.stream(resolution.split("x"))
@@ -57,6 +58,7 @@ public class VideoService {
                 .mapToObj(String::valueOf)
                 .collect(Collectors.joining("x"));
         String halfEncodedVideoUrl = uploadEncodedVideo(originVideoUrl, halfResolution);
+        video.addEncodedVideoUrl(halfEncodedVideoUrl);
 
         // 1/4 사이즈 인코딩
         String quarterResolution = Arrays.stream(resolution.split("x"))
@@ -65,6 +67,7 @@ public class VideoService {
                 .mapToObj(String::valueOf)
                 .collect(Collectors.joining("x"));
         String quarterEncodedVideoUrl = uploadEncodedVideo(originVideoUrl, quarterResolution);
+        video.addEncodedVideoUrl(quarterEncodedVideoUrl);
 
         videoRepository.save(video);
         return video;

--- a/src/main/java/com/j9/bestmoments/service/VideoService.java
+++ b/src/main/java/com/j9/bestmoments/service/VideoService.java
@@ -7,7 +7,6 @@ import com.j9.bestmoments.dto.request.VideoCreateDto;
 import com.j9.bestmoments.dto.request.VideoUpdateDto;
 import com.j9.bestmoments.repository.VideoRepository;
 import com.j9.bestmoments.service.storageService.LocalStorageService;
-import com.j9.bestmoments.util.FileNameGenerator;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.Arrays;
 import java.util.List;
@@ -38,12 +37,12 @@ public class VideoService {
                 .build();
 
         // 원본 영상
-        String originVideoName = FileNameGenerator.generateVideoFileName(video, createDto.video());
+        String originVideoName = FileNameProvider.generateVideoFileName(video, createDto.video());
         String originVideoUrl = storageService.uploadFile(createDto.video(), originVideoName);
         video.setVideoUrl(originVideoUrl);
 
         // 썸네일 이미지
-        String thumbnailName = FileNameGenerator.generateThumbnailImageFileName(video, createDto.thumbnail());
+        String thumbnailName = FileNameProvider.generateThumbnailImageFileName(video, createDto.thumbnail());
         String thumbnailUrl = storageService.uploadFile(createDto.thumbnail(), thumbnailName);
         video.setThumbnailUrl(thumbnailUrl);
 
@@ -72,7 +71,7 @@ public class VideoService {
     }
 
     private String uploadEncodedVideo(String videoUrl, String resolution) {
-        String encodedVideoUrl = FileNameGenerator.generateEncodedVideoFileName(videoUrl, resolution);
+        String encodedVideoUrl = FileNameProvider.generateEncodedVideoFileName(videoUrl, resolution);
         ffmpegService.encodeVideo(videoUrl, encodedVideoUrl, resolution);
         return encodedVideoUrl;
     }
@@ -109,7 +108,7 @@ public class VideoService {
     @Transactional
     public Video update(Video video, VideoUpdateDto updateDto) {
         if (updateDto.thumbnail() != null) {
-            String thumbnailName = FileNameGenerator.generateThumbnailImageFileName(video, updateDto.thumbnail());
+            String thumbnailName = FileNameProvider.generateThumbnailImageFileName(video, updateDto.thumbnail());
             String thumbnailUrl = storageService.uploadFile(updateDto.thumbnail(), thumbnailName);
             video.setThumbnailUrl(thumbnailUrl);
         }


### PR DESCRIPTION
## 🚀 작업 내용
인코딩된 영상 링크들을 제공

## 📝 참고 사항

- Video 엔티티에 인코딩된 영상 Url들을 저장하는 필드를 추가 (직렬화하여 저장)
- 원본 영상 해상도 및 이하의 표준 해상도 `144, 240, 360, 480, 720, 1080, 1440, 2160`로 인코딩한 파일 경로를 제공
- FFmpeg H.264 코덱은 해상도가 16의 배수일 때 인코딩의 성능이 극대화, 인코딩 이전에 짝수 여부를 확인 및 조정

## 🖼️ 스크린샷
영상 조회 시 응답 DTO 수정
![image](https://github.com/user-attachments/assets/547a0c18-43e7-4b32-b153-e589c91f1479)

