### PR TITLE
일부 동영상이 업로드되지 않는 오류 해결

### DIFF
--- a/src/main/java/com/j9/bestmoments/constants/ImageFileTypes.java
+++ b/src/main/java/com/j9/bestmoments/constants/ImageFileTypes.java
@@ -19,7 +19,7 @@ public enum ImageFileTypes {
     private final String contentType;
 
     public static boolean contains(String contentType) {
-        System.out.println(contentType);
+//        System.out.println(contentType);
         if (contentType == null) {
             return false;
         }

--- a/src/main/java/com/j9/bestmoments/service/FfmpegService.java
+++ b/src/main/java/com/j9/bestmoments/service/FfmpegService.java
@@ -68,9 +68,11 @@ public class FfmpegService {
 
             // FFmpeg의 출력에서 해상도를 파싱하여 추출
             while ((line = reader.readLine()) != null) {
-                if (line.contains("Video:")) {
-                    String[] parts = line.split(",");
-                    for (String part : parts) {
+                if (!line.contains("Video:")) {
+                    continue;
+                }
+                for (String parts : line.split(",")) {
+                    for (String part : parts.split(" ")) {
                         if (part.trim().matches("\\d{2,}x\\d{2,}")) {
                             resolution = part.trim(); // 해상도 부분을 찾음
                             break;

--- a/src/main/java/com/j9/bestmoments/service/FfmpegService.java
+++ b/src/main/java/com/j9/bestmoments/service/FfmpegService.java
@@ -38,10 +38,10 @@ public class FfmpegService {
 
             // 로그 스트림 처리
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    System.out.println(line);  // 로그를 출력하거나 저장할 수 있습니다.
-                }
+//                String line;
+//                while ((line = reader.readLine()) != null) {
+//                    log.info(line);  // 로그를 출력하거나 저장할 수 있습니다.
+//                }
             }
 
             int exitCode = process.waitFor();


### PR DESCRIPTION
## 🚀 작업 내용

동영상 업로드 중 발생하는 오류 원인 확인
- ffmpeg 해상도 읽는 중 발생

## 📝 참고 사항

문자열 파싱 방식을 수정

기존 방식 : `,` 를 기준으로 `split`한 후, 정규식을 통해 해상도를 추출
```
Stream #0:0[0x1](und): Video: h264 (Main) (avc1 / 0x31637661), yuv420p(progressive), 1920x1080, 1796 kb/s, 72.58 fps, 60 tbr, 60k tbn (default)
```
하지만 아래와 같은 형식도 존재함을 확인
```
Stream #0:0[0x1](und): Video: h264 (Main) (avc1 / 0x31637661), yuv420p(progressive), 1280x720 [SAR 1:1 DAR 16:9], 7666 kb/s, 60 fps, 60 tbr, 15360 tbn (default)
```
공백 문자로 한 번 더 파싱을 수행하도록 변경

## 🖼️ 스크린샷
![image](https://github.com/user-attachments/assets/87e30a03-e134-426a-9154-2a0150472a50)

